### PR TITLE
refactor scrapper to enter a zipcode

### DIFF
--- a/costco-vitamins-supplements-scrapper.ts
+++ b/costco-vitamins-supplements-scrapper.ts
@@ -1,42 +1,89 @@
 import puppeteer from "puppeteer";
 
 // costco urls
-const COSTCO_SAME_DAY_URL = `https://sameday.costco.com/store/costco/storefront?utm_source=nav&zipcode=11201`
+//const COSTCO_SAME_DAY_URL = `https://sameday.costco.com/store/costco/storefront?utm_source=nav&zipcode=11201`
 const COSTCO_SAME_DAY_VITAMINS_SUPPLEMENTS_URL = `https://sameday.costco.com/store/costco/collections/rc-vitamins-supplements`
 
 // graphql path
 const GRAPHQL_PATH = `graphql?operationName=Items&variables`
 
 // scraped url
-const SCRAPPED_URL = `${COSTCO_SAME_DAY_VITAMINS_SUPPLEMENTS_URL}`
+const SCRAPPED_URL = COSTCO_SAME_DAY_VITAMINS_SUPPLEMENTS_URL
 
 // main scrapper function
 const runScrapper = async () => {
+    console.log('Starting scraper...')
+
     // 1. launch browser and create a new blank page
     const browser = await puppeteer.launch({
         headless: false,
     })
+    console.log('Browser launched successfully')
+
     const page = await browser.newPage()
+    console.log('New page created')
 
     // 2. configure context and geolocation permission
     const context = browser.defaultBrowserContext()
     await context.overridePermissions(SCRAPPED_URL, ["geolocation"])
+    console.log('Geolocation permissions configured')
 
-    // 3. set up request interceptors to filter graphql requests
-    await page.setRequestInterception(true)
+    // 3. navigate to the page without interception
+    console.log('Navigating to target URL:', SCRAPPED_URL)
+    await page.goto(SCRAPPED_URL, {
+        waitUntil: "networkidle2"
+    })
+    console.log('Successfully navigated to target URL')
 
+    // 4. handle ZIP code entry before setting up interceptors
+    const ZIP_CODE = "11201"
+    try {
+        console.log('Attempting to enter ZIP code...')
+        await page.waitForSelector('input[placeholder="Enter ZIP code"]', {
+            timeout: 5000
+        })
+        await page.type('input[placeholder="Enter ZIP code"]', ZIP_CODE)
+        console.log('ZIP code entered successfully')
+
+        await page.click('button[type="submit"]')
+        console.log('Submit button clicked')
+
+        // Wait for network to be idle instead of navigation
+        await page.waitForNetworkIdle({ timeout: 60000 })
+        console.log('Network is idle after ZIP code submission')
+
+        // Add a small delay before refresh
+        await new Promise(resolve => setTimeout(resolve, 2000))
+
+        // Refresh the page and wait for network idle
+        console.log('Refreshing page to capture fresh GraphQL responses...')
+        await page.reload({ waitUntil: ["networkidle0", "domcontentloaded"], timeout: 60000 })
+        console.log('Page refreshed successfully')
+
+        // Add another small delay after refresh
+        await new Promise(resolve => setTimeout(resolve, 2000))
+
+    } catch (error) {
+        console.error(`Error during ZIP code handling:`, error)
+        throw error
+    }
+
+    // 5. set up request interceptors for GraphQL
     const productData: any[] = [] // array to store product data
+    await page.setRequestInterception(true)
+    console.log('Request interception enabled')
 
     page.on('request', (request) => {
-        // filter requests to capture only the graphql calss for products
+        // filter requests to capture only the graphql calls for products
         if (request.url().includes(GRAPHQL_PATH)) {
             request.continue() // let the request pass through
+            console.log('GraphQL request detected and allowed')
         } else {
-            request.abort() // abort all other requests
+            request.abort() // abort non-GraphQL requests
+            console.log('Non-GraphQL request aborted')
         }
     })
 
-    // 4. capture response for relevant graphql requests
     page.on('response', async (response) => {
         // check if response url matches target graphql endpoint
         if (response.url().includes(GRAPHQL_PATH)) {
@@ -44,6 +91,7 @@ const runScrapper = async () => {
                 const json = await response.json()
                 if (json && json.data) {
                     productData.push(json.data) // store the data
+                    console.log('Successfully captured GraphQL response data')
                 }
             } catch (error) {
                 console.error(`Error parsing response body:`, error)
@@ -51,16 +99,16 @@ const runScrapper = async () => {
         }
     })
 
-    // 5. navigate to the category page you want to scrape
-    await page.goto(SCRAPPED_URL, {
-        waitUntil: "networkidle2"
-    })
-
     // 6. wait for page data to load and capture responses
+    console.log('Waiting for final data capture...')
     await new Promise(resolve => setTimeout(resolve, 5000))
+    console.log('Data capture wait period completed')
 
     // 7. close the browser
     //await browser.close()
+    console.log('Scraping process completed')
+
+    return productData
 }
 
 // run the scrapper


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `runScrapper()` to include ZIP code entry and improve logging.
> 
>   - **Behavior**:
>     - Adds ZIP code entry functionality in `runScrapper()` before setting up request interceptors.
>     - Waits for ZIP code input field, enters ZIP code, submits, and waits for network idle.
>     - Refreshes page after ZIP code submission to capture fresh GraphQL responses.
>   - **Logging**:
>     - Adds detailed logging for each step in `runScrapper()` to track the scraping process.
>   - **Misc**:
>     - Moves request interception setup to occur after ZIP code entry.
>     - Removes unused `COSTCO_SAME_DAY_URL` constant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Ffaisal-invisible-hand&utm_source=github&utm_medium=referral)<sup> for 56f508ceb6c36e251a9c595a6460f4d9bc36cd9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->